### PR TITLE
Update to abstract-leveldown 4 and levelup 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - 4
+  - 6
+  - 8
+  - 9

--- a/index.js
+++ b/index.js
@@ -5,9 +5,5 @@ module.exports = function (db, prefix, opts) {
   if (typeof prefix === 'object' && !opts) return module.exports(db, null, prefix)
   if (!opts) opts = {}
 
-  opts.db = function () {
-    return subdown(db, prefix, opts)
-  }
-
-  return levelup(opts)
+  return levelup(subdown(db, prefix, opts), opts)
 }

--- a/leveldown.js
+++ b/leveldown.js
@@ -2,20 +2,24 @@ var util = require('util')
 var abstract = require('abstract-leveldown')
 var wrap = require('level-option-wrap')
 
-var END = new Buffer([0xff])
+var END = Buffer.from([0xff])
 
 var concat = function (prefix, key, force) {
   if (typeof key === 'string' && (force || key.length)) return prefix + key
-  if (Buffer.isBuffer(key) && (force || key.length)) return Buffer.concat([new Buffer(prefix), key])
+  if (Buffer.isBuffer(key) && (force || key.length)) return Buffer.concat([Buffer.from(prefix), key])
   return key
 }
 
 var SubIterator = function (ite, prefix) {
   this.iterator = ite
   this.prefix = prefix
+
+  abstract.AbstractIterator.call(this)
 }
 
-SubIterator.prototype.next = function (cb) {
+util.inherits(SubIterator, abstract.AbstractIterator)
+
+SubIterator.prototype._next = function (cb) {
   var self = this
   this.iterator.next(cb && function (err, key, value) {
     if (err) return cb(err)
@@ -24,7 +28,7 @@ SubIterator.prototype.next = function (cb) {
   })
 }
 
-SubIterator.prototype.end = function (cb) {
+SubIterator.prototype._end = function (cb) {
   this.iterator.end(cb)
 }
 
@@ -85,27 +89,22 @@ SubDown.prototype._open = function (opts, cb) {
   }
 }
 
-SubDown.prototype.close = function () {
+SubDown.prototype._close = function () {
   this.leveldown.close.apply(this.leveldown, arguments)
 }
 
-SubDown.prototype.setDb = function () {
-  this.leveldown.setDb.apply(this.leveldown, arguments)
-}
-
-SubDown.prototype.put = function (key, value, opts, cb) {
+SubDown.prototype._put = function (key, value, opts, cb) {
   this.leveldown.put(concat(this.prefix, key), value, opts, cb)
 }
 
-SubDown.prototype.get = function (key, opts, cb) {
+SubDown.prototype._get = function (key, opts, cb) {
   this.leveldown.get(concat(this.prefix, key), opts, cb)
 }
 
-SubDown.prototype.del = function (key, opts, cb) {
+SubDown.prototype._del = function (key, opts, cb) {
   this.leveldown.del(concat(this.prefix, key), opts, cb)
 }
 
-SubDown.prototype.batch =
 SubDown.prototype._batch = function (operations, opts, cb) {
   if (arguments.length === 0) return new abstract.AbstractChainedBatch(this)
   if (!Array.isArray(operations)) return this.leveldown.batch.apply(null, arguments)
@@ -117,22 +116,6 @@ SubDown.prototype._batch = function (operations, opts, cb) {
   }
 
   this.leveldown.batch(subops, opts, cb)
-}
-
-SubDown.prototype.approximateSize = function (start, end, cb) {
-  this.leveldown.approximateSize.apply(this.leveldown, arguments)
-}
-
-SubDown.prototype.getProperty = function () {
-  return this.leveldown.getProperty.apply(this.leveldown, arguments)
-}
-
-SubDown.prototype.destroy = function () {
-  return this.leveldown.destroy.apply(this.leveldown, arguments)
-}
-
-SubDown.prototype.repair = function () {
-  return this.leveldown.repair.apply(this.leveldown, arguments)
 }
 
 var extend = function (xopts, opts) {
@@ -155,7 +138,7 @@ var fixRange = function (opts) {
   return (!opts.reverse || (!opts.end && !opts.start)) ? opts : {start: opts.end, end: opts.start}
 }
 
-SubDown.prototype.iterator = function (opts) {
+SubDown.prototype._iterator = function (opts) {
   if (!opts) opts = {}
   var xopts = extend(wrap(fixRange(opts), this._wrap), opts)
   return new SubIterator(this.leveldown.iterator(xopts), this.prefix)

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "sublevels implemented using leveldowns",
   "main": "index.js",
   "dependencies": {
-    "abstract-leveldown": "^2.4.1",
+    "abstract-leveldown": "^4.0.2",
     "level-option-wrap": "^1.1.0",
-    "levelup": "^1.2.1"
+    "levelup": "^2.0.1"
   },
   "devDependencies": {
-    "memdown": "^1.1.0",
-    "standard": "^5.3.1",
+    "memdown": "^2.0.0",
+    "standard": "^10.0.3",
     "tape": "^4.2.2"
   },
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -3,20 +3,18 @@ var memdown = require('memdown')
 var subdown = require('../leveldown')
 var levelup = require('levelup')
 var testCommon = require('./common')
-var testBuffer = new Buffer('this-is-test-data')
 
 require('abstract-leveldown/abstract/open-test').args(down, test, testCommon)
-require('abstract-leveldown/abstract/open-test').open(down, test, testCommon)
 require('abstract-leveldown/abstract/del-test').all(down, test, testCommon)
 require('abstract-leveldown/abstract/get-test').all(down, test, testCommon)
 require('abstract-leveldown/abstract/put-test').all(down, test, testCommon)
-require('abstract-leveldown/abstract/put-get-del-test').all(down, test, testCommon, testBuffer)
+require('abstract-leveldown/abstract/put-get-del-test').all(down, test, testCommon)
 require('abstract-leveldown/abstract/batch-test').all(down, test, testCommon)
 require('abstract-leveldown/abstract/chained-batch-test').all(down, test, testCommon)
 require('abstract-leveldown/abstract/close-test').close(down, test, testCommon)
 require('abstract-leveldown/abstract/iterator-test').all(down, test, testCommon)
-require('abstract-leveldown/abstract/ranges-test').all(down, test, testCommon)
+require('abstract-leveldown/abstract/iterator-range-test').all(down, test, testCommon)
 
 function down (loc) {
-  return subdown(levelup(loc, {db: memdown}), 'test')
+  return subdown(levelup(memdown()), 'test')
 }


### PR DESCRIPTION
Hey,

I updated the dependencies and change the implementation to pass the tests for the latest `abstract-leveldown`.

Also: How do you feel about maybe moving this to the level org?
 There's a discussion going on at https://github.com/Level/community/issues/14