### PR TITLE
Pass on fillCache option to SubIterator

### DIFF
--- a/leveldown.js
+++ b/leveldown.js
@@ -132,6 +132,7 @@ function extend (xopts, opts) {
   xopts.keyAsBuffer = opts.keyAsBuffer
   xopts.valueAsBuffer = opts.valueAsBuffer
   xopts.reverse = opts.reverse
+  xopts.fillCache = opts.fillCache
   return xopts
 }
 


### PR DESCRIPTION
Closes https://github.com/Level/subleveldown/issues/56

This allows subleveldown instances to fill the cache when reading data from a stream with the fillCache option set to true.