### PR TITLE
Use reachdown

### DIFF
--- a/matchdown.js
+++ b/matchdown.js
@@ -1,0 +1,8 @@
+module.exports = function matchdown (db, type) {
+  // Skip layers that we handle ourselves
+  if (type === 'levelup') return false
+  if (type === 'encoding-down') return false
+  if (type === 'deferred-leveldown') return false
+
+  return true
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "reachdown": "^1.0.0"
   },
   "devDependencies": {
+    "@adorsys/encrypt-down": "^2.0.1",
     "after": "^0.8.2",
     "coveralls": "^3.0.2",
     "dependency-check": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "reachdown": "^1.0.0"
   },
   "devDependencies": {
-    "@adorsys/encrypt-down": "^2.0.1",
     "after": "^0.8.2",
     "coveralls": "^3.0.2",
     "dependency-check": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "encoding-down": "^6.2.0",
     "inherits": "^2.0.3",
     "level-option-wrap": "^1.1.0",
-    "levelup": "^4.2.0"
+    "levelup": "^4.2.0",
+    "reachdown": "^1.0.0"
   },
   "devDependencies": {
     "after": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "hallmark": "^2.0.0",
     "level-community": "^3.0.0",
     "level-concat-iterator": "^2.0.1",
+    "memdb": "^1.3.1",
     "memdown": "^5.0.0",
     "nyc": "^14.0.0",
     "standard": "^14.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ var subdown = require('../leveldown')
 var subdb = require('..')
 var levelup = require('levelup')
 var reachdown = require('reachdown')
+var memdb = require('memdb')
 var encrypt = require('@adorsys/encrypt-down')
 
 // Test abstract-leveldown compliance
@@ -388,6 +389,37 @@ test('subleveldown on encrypt-down', function (t) {
     reachdown(db).get('!test!key', { asBuffer: false }, function (err, value) {
       t.ifError(err, 'no memdown get error')
       t.isNot(value, 'value', 'value is encrypted')
+    })
+  })
+})
+
+test('legacy memdb (old levelup)', function (t) {
+  t.plan(7)
+
+  // Should not result in double json encoding
+  var db = memdb({ valueEncoding: 'json' })
+  var sub = subdb(db, 'test', { valueEncoding: 'json' })
+
+  // Integration with memdb still works because subleveldown waits to reachdown
+  // until the (old levelup) db is open. Reaching down then correctly lands on
+  // the memdown db. If subleveldown were to reachdown immediately it'd land on
+  // the old deferred-leveldown (which when unopened doesn't have a reference to
+  // the memdown db yet) so we'd be unable to persist anything.
+  t.is(Object.getPrototypeOf(reachdown(db)).constructor.name, 'DeferredLevelDOWN')
+
+  sub.put('key', { a: 1 }, function (err) {
+    t.ifError(err, 'no put error')
+
+    sub.get('key', function (err, value) {
+      t.ifError(err, 'no get error')
+      t.same(value, { a: 1 })
+    })
+
+    t.is(Object.getPrototypeOf(reachdown(db)).constructor.name, 'MemDOWN')
+
+    reachdown(db).get('!test!key', { asBuffer: false }, function (err, value) {
+      t.ifError(err, 'no get error')
+      t.is(value, '{"a":1}')
     })
   })
 })


### PR DESCRIPTION
Use [`reachdown`](https://github.com/vweevers/reachdown) instead of:

https://github.com/Level/subleveldown/blob/992353b336eef5088843ca628c9e60cc0b8077c5/leveldown.js#L183-L189

Two notable differences:

- `reachdown` does not do `if (typeof db.down === 'function') return db.down(type)`. That's OK, we didn't add a `down()` method anywhere nor did we advertise this ability.
- `subleveldown` now doesn't just get the innermost db (`db.db.db..`). Instead, it traverses down until `db` is not a `levelup`, `deferred-leveldown` or `encoding-down` instance. This means, if there are additional layers (e.g. `encrypt-down`, `cachedown`) `subleveldown` stops there, not necessarily at the "storage layer".

Canary-tested against `cabal-core` (which uses the old `memdb`, I'll be sending them a PR to switch to `level-mem`).

This PR fails on node 6 because of a new test on `encrypt-down` which uses ES6. I'll see if I can make that test dependency-free by mocking an `abstract-leveldown`.