### PR TITLE
Refactor open() and close() to mostly bypass levelup

### DIFF
--- a/leveldown.js
+++ b/leveldown.js
@@ -73,6 +73,14 @@ function SubDown (db, prefix, opts) {
     this.leveldown = reachdown(db, matchdown, false)
   }
 
+  if (reachdown(this.leveldown, 'deferred-leveldown') === this.leveldown) {
+    // When old deferred-leveldown is unopened it doesn't have a reference
+    // to the underlying db yet and we therefore cannot access it.
+    throw new Error('Not compatible with levelup < 2.0.0 / deferred-leveldown < 2.0.0')
+  } else if (!this.leveldown.status) {
+    throw new Error('Not compatible with abstract-leveldown < 2.4.0')
+  }
+
   // For compatibility with reachdown
   // TODO (next major): remove this.leveldown in favor of this.db
   this.db = this.leveldown

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "test"
   },
   "dependencies": {
-    "abstract-leveldown": "^6.1.1",
+    "abstract-leveldown": "^6.2.1",
     "encoding-down": "^6.2.0",
     "inherits": "^2.0.3",
     "level-option-wrap": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "hallmark": "^2.0.0",
     "level-community": "^3.0.0",
     "level-concat-iterator": "^2.0.1",
-    "memdb": "^1.3.1",
     "memdown": "^5.0.0",
     "nyc": "^14.0.0",
     "standard": "^14.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,6 @@ var subdown = require('../leveldown')
 var subdb = require('..')
 var levelup = require('levelup')
 var reachdown = require('reachdown')
-var memdb = require('memdb')
 var abstract = require('abstract-leveldown')
 var inherits = require('util').inherits
 
@@ -465,37 +464,6 @@ test('subleveldown on intermediate layer', function (t) {
     reachdown(db).get('mitm!test!key', { asBuffer: false }, function (err, value) {
       t.ifError(err, 'no memdown get error')
       t.is(value, 'value')
-    })
-  })
-})
-
-test.skip('legacy memdb (old levelup)', function (t) {
-  t.plan(7)
-
-  // Should not result in double json encoding
-  var db = memdb({ valueEncoding: 'json' })
-  var sub = subdb(db, 'test', { valueEncoding: 'json' })
-
-  // Integration with memdb still works because subleveldown waits to reachdown
-  // until the (old levelup) db is open. Reaching down then correctly lands on
-  // the memdown db. If subleveldown were to reachdown immediately it'd land on
-  // the old deferred-leveldown (which when unopened doesn't have a reference to
-  // the memdown db yet) so we'd be unable to persist anything.
-  t.is(Object.getPrototypeOf(reachdown(db)).constructor.name, 'DeferredLevelDOWN')
-
-  sub.put('key', { a: 1 }, function (err) {
-    t.ifError(err, 'no put error')
-
-    sub.get('key', function (err, value) {
-      t.ifError(err, 'no get error')
-      t.same(value, { a: 1 })
-    })
-
-    t.is(Object.getPrototypeOf(reachdown(db)).constructor.name, 'MemDOWN')
-
-    reachdown(db).get('!test!key', { asBuffer: false }, function (err, value) {
-      t.ifError(err, 'no get error')
-      t.is(value, '{"a":1}')
     })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -120,7 +120,7 @@ test('SubDb main function', function (t) {
       t.is(sub.db instanceof encoding, true, 'is encoding-down instance')
       t.is(sub.db.db instanceof subdown, true, 'is subdown instance')
       t.is(sub.db.db.type, 'subleveldown', '.type is subleveldown')
-      t.is(sub.db.db.leveldown instanceof memdown, true, 'memdown')
+      t.is(sub.db.db.db instanceof memdown, true, 'memdown')
       t.end()
     })
   })
@@ -215,11 +215,11 @@ test('SubDb main function', function (t) {
     function verify () {
       t.is(sub1.db instanceof encoding, true, 'sub1 encoding-down')
       t.is(sub1.db.db.prefix, '!test1!', 'sub1 prefix ok')
-      t.is(sub1.db.db.leveldown instanceof memdown, true, 'memdown')
+      t.is(sub1.db.db.db instanceof memdown, true, 'memdown')
       t.is(sub2.db instanceof encoding, true, 'sub2 encoding-down')
       t.is(sub2.db.db.prefix, '!test1!!test2!', 'sub2 prefix ok')
       t.is(sub2.db.db.type, 'subleveldown', '.type is subleveldown')
-      t.is(sub2.db.db.leveldown instanceof memdown, true, 'memdown')
+      t.is(sub2.db.db.db instanceof memdown, true, 'memdown')
     }
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -124,7 +124,7 @@ test('SubDb main function', function (t) {
     })
   })
 
-  t.test('different sub levels can have different encodings', function (t) {
+  t.test('different sublevels can have different encodings', function (t) {
     t.plan(6)
     var db = levelup(memdown())
     var sub1 = subdb(db, 'test1', {
@@ -150,14 +150,13 @@ test('SubDb main function', function (t) {
     })
   })
 
-  t.test('wrap a closed levelup and re-open levelup', function (t) {
+  t.test('cannot create a sublevel on a closed db', function (t) {
     t.plan(4)
     var db = levelup(memdown())
     db.once('open', function () {
       db.close(function (err) {
         t.error(err, 'no error')
 
-        // Can't create a sublevel at this point
         subdb(db, 'test').on('error', function (err) {
           t.is(err.message, 'Database is not open', 'sublevel not opened')
         })
@@ -173,7 +172,7 @@ test('SubDb main function', function (t) {
     })
   })
 
-  t.test('wrap opened levelup, close levelup and sublevel', function (t) {
+  t.test('can close db and sublevel once opened', function (t) {
     t.plan(3)
 
     levelup(memdown(), function (err, db) {
@@ -193,7 +192,7 @@ test('SubDb main function', function (t) {
     })
   })
 
-  t.test('wrap opened levelup, close levelup and sublevel while sublevel is opening', function (t) {
+  t.test('cannot close db while sublevel is opening', function (t) {
     t.plan(5)
 
     levelup(memdown(), function (err, db) {
@@ -216,26 +215,7 @@ test('SubDb main function', function (t) {
     })
   })
 
-  t.test('wrap opened levelup, close levelup while sublevel is opening', function (t) {
-    t.plan(5)
-
-    levelup(memdown(), function (err, db) {
-      t.ifError(err, 'no open error')
-      var sub = subdb(db, 'test')
-
-      sub.on('error', (err) => {
-        t.is(err.message, 'Database is not open')
-      })
-
-      db.close(function (err) {
-        t.ifError(err, 'no close error')
-        t.is(reachdown(sub, 'subleveldown').status, 'new')
-        t.is(reachdown(sub).status, 'closed')
-      })
-    })
-  })
-
-  t.test('wrap closing levelup', function (t) {
+  t.test('cannot create sublevel while db is closing', function (t) {
     t.plan(6)
 
     levelup(memdown(), function (err, db) {
@@ -260,7 +240,7 @@ test('SubDb main function', function (t) {
     })
   })
 
-  t.test('wrap levelup and encoding-down, close sublevel and re-open', function (t) {
+  t.test('can reopen a sublevel without affecting encoding-down state of db', function (t) {
     t.plan(3)
     var db = levelup(encoding(memdown()))
 

--- a/test/index.js
+++ b/test/index.js
@@ -47,43 +47,43 @@ suite({
 // Additional tests for this implementation
 test('SubDown constructor', function (t) {
   t.test('can be called without new', function (t) {
-    var sub = subdown()
+    var sub = subdown(memdown())
     t.is(sub instanceof subdown, true, 'instanceof subdown')
     t.end()
   })
   t.test('missing prefix and missing separator', function (t) {
-    var sub = subdown()
+    var sub = subdown(memdown())
     t.is(sub.prefix, '!!')
     t.end()
   })
   t.test('prefix and missing separator', function (t) {
-    var sub = subdown({}, 'prefix')
+    var sub = subdown(memdown(), 'prefix')
     t.is(sub.prefix, '!prefix!')
     t.end()
   })
   t.test('prefix and separator (as string)', function (t) {
-    var sub = subdown({}, 'prefix', '%')
+    var sub = subdown(memdown(), 'prefix', '%')
     t.is(sub.prefix, '%prefix%')
     t.end()
   })
   t.test('prefix and separator (as options)', function (t) {
-    var sub = subdown({}, 'prefix', { separator: '%' })
+    var sub = subdown(memdown(), 'prefix', { separator: '%' })
     t.is(sub.prefix, '%prefix%')
     t.end()
   })
   t.test('prefix with same initial character as separator is sliced', function (t) {
-    var sub = subdown({}, '!prefix')
+    var sub = subdown(memdown(), '!prefix')
     t.is(sub.prefix, '!prefix!')
     t.end()
   })
   t.test('prefix with same ending character as separator is sliced', function (t) {
-    var sub = subdown({}, 'prefix!')
+    var sub = subdown(memdown(), 'prefix!')
     t.is(sub.prefix, '!prefix!')
     t.end()
   })
   // TODO we're currently not guarded by multiple separators in the prefix
   // t.test('repeated separator is slices off from prefix parameter', function (t) {
-  //   var sub = subdown({}, '!!prefix!!')
+  //   var sub = subdown(memdown(), '!!prefix!!')
   //   t.is(sub.prefix, '!prefix!')
   //   t.end()
   // })
@@ -103,6 +103,7 @@ test('SubDb main function', function (t) {
     t.plan(1)
 
     var mockdb = {
+      status: 'new',
       open: function (cb) {
         process.nextTick(cb, new Error('error from underlying store'))
       }
@@ -297,6 +298,7 @@ test('SubDb main function', function (t) {
     t.plan(2)
 
     var mockdb = {
+      status: 'new',
       open: function (cb) {
         process.nextTick(cb)
       },
@@ -467,7 +469,7 @@ test('subleveldown on intermediate layer', function (t) {
   })
 })
 
-test('legacy memdb (old levelup)', function (t) {
+test.skip('legacy memdb (old levelup)', function (t) {
   t.plan(7)
 
   // Should not result in double json encoding


### PR DESCRIPTION
Closes #60, closes #77, closes #78, and opens up the possibility to add a manifest.

I was sitting around thinking "how can i make subleveldown more complicated" and this PR is the result.