### PR TITLE
Fix double prefixes

### DIFF
--- a/leveldown.js
+++ b/leveldown.js
@@ -57,7 +57,8 @@ function SubDown (db, prefix, opts) {
 
   this.db = db
   this.leveldown = null
-  this.prefix = separator + prefix + separator
+  this.ownPrefix = separator + prefix + separator
+  this.prefix = this.ownPrefix
   this._beforeOpen = opts.open
 
   var self = this
@@ -88,8 +89,8 @@ SubDown.prototype._open = function (opts, cb) {
     var subdb = reachdown(self.db, 'subleveldown')
 
     if (subdb && subdb.prefix) {
-      self.prefix = subdb.prefix + self.prefix
-      self.leveldown = reachdown(subdb.db, matchdown, false)
+      self.prefix = subdb.prefix + self.ownPrefix
+      self.leveldown = subdb.leveldown || reachdown(subdb.db, matchdown, false)
     } else {
       self.leveldown = reachdown(self.db, matchdown, false)
     }

--- a/leveldown.js
+++ b/leveldown.js
@@ -90,7 +90,7 @@ SubDown.prototype._open = function (opts, cb) {
 
     if (subdb && subdb.prefix) {
       self.prefix = subdb.prefix + self.ownPrefix
-      self.leveldown = subdb.leveldown || reachdown(subdb.db, matchdown, false)
+      self.leveldown = subdb.leveldown
     } else {
       self.leveldown = reachdown(self.db, matchdown, false)
     }

--- a/matchdown.js
+++ b/matchdown.js
@@ -3,6 +3,7 @@ module.exports = function matchdown (db, type) {
   if (type === 'levelup') return false
   if (type === 'encoding-down') return false
   if (type === 'deferred-leveldown') return false
+  if (type === 'subleveldown') return false
 
   return true
 }

--- a/matchdown.js
+++ b/matchdown.js
@@ -3,7 +3,6 @@ module.exports = function matchdown (db, type) {
   if (type === 'levelup') return false
   if (type === 'encoding-down') return false
   if (type === 'deferred-leveldown') return false
-  if (type === 'subleveldown') return false
 
   return true
 }


### PR DESCRIPTION
In two situations:

- When reopening a nested sublevel, because on open we add the parent's prefix to the child's prefix. Open twice, and you get a double prefix. Fixed by keeping around the original prefix.
- When having more than 2 nested sublevels. This resulted in subdown wrapping subdown, effectively applying a double prefix to keys. Fixed by tweaking the unwrapping voodoo.

Closes #78. This PR is an alternative to #79, which fixes more issues but is WIP, more invasive and semver-major, while this is semver-patch (with [a caveat](https://github.com/Level/subleveldown/issues/78#issuecomment-539252577)).