### PR TITLE
Breaking: parent db must support deferredOpen

### DIFF
--- a/matchdown.js
+++ b/matchdown.js
@@ -3,6 +3,7 @@ module.exports = function matchdown (db, type) {
   if (type === 'levelup') return false
   if (type === 'encoding-down') return false
   if (type === 'deferred-leveldown') return false
+  if (type === 'subleveldown') return false
 
   return true
 }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "test": "test"
   },
   "dependencies": {
-    "abstract-leveldown": "^6.1.1",
+    "abstract-leveldown": "^6.2.3",
     "encoding-down": "^6.2.0",
     "inherits": "^2.0.3",
     "level-option-wrap": "^1.1.0",
     "levelup": "^4.3.1",
-    "reachdown": "^1.0.0"
+    "reachdown": "^1.1.0"
   },
   "devDependencies": {
     "after": "^0.8.2",
@@ -31,7 +31,6 @@
     "hallmark": "^2.0.0",
     "level-community": "^3.0.0",
     "level-concat-iterator": "^2.0.1",
-    "memdb": "^1.3.1",
     "memdown": "^5.0.0",
     "nyc": "^14.0.0",
     "standard": "^14.0.0",


### PR DESCRIPTION
**Parent database must support deferredOpen**

By parent we mean:

```js
var parent = require('level')('db')
var sublevel = require('subleveldown')(parent, 'a')
```

By [deferredOpen](https://github.com/Level/supports#deferredopen-boolean) we mean that the db opens itself and defers operations until it's open. Currently that's only supported by `levelup` (and `levelup` factories like `level`). Before, `subleveldown` would also accept `abstract-leveldown` db's that were not wrapped in `levelup`.

**Better isolation**

Opening and closing a sublevel no longer opens or closes the parent db. The sublevel does wait for the parent to open (which in the case of `levelup` already happens automatically) but never initiates
a state change on the parent.

If one closes the parent but not the sublevel, subsequent operations on the sublevel (like `get` and `put`) will yield an error, to prevent segmentation faults from underlying stores.

**Drops support of old modules**

- `memdb` (use `level-mem` instead)
- `deferred-leveldown` < 2.0.0 (and thus `levelup` < 2.0.0)
- `abstract-leveldown` < 2.4.0

**Rejects new sublevels on a closing or closed database**

```js
db.close(function (err) {
  subdb(db, 'example').on('error', function (err) {
    throw err // Error: Parent database is not open
  })
})
```

```js
subdb(db, 'example').on('error', (err) => {
  throw err // Error: Parent database is not open
})

db.close(function () {})
```

---

Closes #84, closes #83, closes #60 and paves the way for https://github.com/Level/community/issues/83.