### PR TITLE
Run abstract-leveldown tests on levelup interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "encoding-down": "^6.2.0",
     "inherits": "^2.0.3",
     "level-option-wrap": "^1.1.0",
-    "levelup": "github:Level/levelup#19e1967",
+    "levelup": "^4.4.0",
     "reachdown": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "test": "test"
   },
   "dependencies": {
-    "abstract-leveldown": "^6.2.3",
+    "abstract-leveldown": "github:Level/abstract-leveldown#0a61ef4",
     "encoding-down": "^6.2.0",
     "inherits": "^2.0.3",
     "level-option-wrap": "^1.1.0",
-    "levelup": "^4.3.1",
+    "levelup": "github:Level/levelup#19e1967",
     "reachdown": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "test"
   },
   "dependencies": {
-    "abstract-leveldown": "github:Level/abstract-leveldown#0a61ef4",
+    "abstract-leveldown": "^6.3.0",
     "encoding-down": "^6.2.0",
     "inherits": "^2.0.3",
     "level-option-wrap": "^1.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,28 @@ runSuite(function factory () {
   return subdown(down, 'test')
 })
 
+// Test levelup interface
+suite({
+  test: test,
+  factory: function () {
+    // This is a levelup instance, but we're testing it as abstract-leveldown :)
+    return subdb(levelup(encoding(memdown())), 'test')
+  },
+  // Unsupported features
+  seek: false,
+  createIfMissing: false,
+  errorIfExists: false,
+
+  // Opt-in to new clear() tests
+  clear: true,
+
+  // Adapt for levelup
+  promises: true,
+  status: false,
+  serialize: false,
+  encodings: true
+})
+
 // Additional tests for this implementation
 test('SubDown constructor', function (t) {
   t.test('can be called without new', function (t) {


### PR DESCRIPTION
Depends on https://github.com/Level/abstract-leveldown/pull/364 and https://github.com/Level/levelup/pull/692.

Working towards https://github.com/Level/community/issues/58.