### PR TITLE
Don't mutate arguments in SubIterator._next

### DIFF
--- a/leveldown.js
+++ b/leveldown.js
@@ -32,7 +32,7 @@ SubIterator.prototype._next = function (cb) {
   this.iterator.next(function (err, key, value) {
     if (err) return cb(err)
     if (key) key = key.slice(self.prefix.length)
-    cb.apply(null, arguments)
+    cb(err, key, value)
   })
 }
 


### PR DESCRIPTION
This method mutates an argument and subsequently references `arguments`. In JS strict mode, the `arguments` symbol references a copy of the initial function arguments; it does not reflect mutations made to the arguments in the body of the function ([see spec](https://www.ecma-international.org/ecma-262/5.1/#sec-10.6))—so the mutation is inadvertently dropped. I've fixed this issue by using the argument names directly rather than the `arguments` objects.