### PR TITLE
readme: full output for 'regular levelup' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ The `example` and `nested` db's are just regular [`levelup`][levelup] instances:
 ```js
 example.put('hello', 'world', function () {
   nested.put('hi', 'welt', function () {
-    // will print {key:'hello', value:'world'}
+    // stream all data from the parent
     example.createReadStream().on('data', console.log)
+    // { key: '!nested!hi', value: 'welt' }
+    // {key:'hello', value:'world'}
   })
 })
 ```


### PR DESCRIPTION
the readme example currently shows only the parent / non-namespaced output from a readstream. This edit hopefully makes it clear to the rookies and lightweights that all data, including namespaced keys from sublevels, is included when streaming.