### PR TITLE
fix: remove unused dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .nyc_output/
 coverage/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "abstract-leveldown": "^7.2.0",
     "encoding-down": "^7.1.0",
-    "inherits": "^2.0.3",
     "level-option-wrap": "^1.1.0",
     "levelup": "^5.1.1",
     "reachdown": "^1.1.0"


### PR DESCRIPTION
Hi,

I found that one dependency (inherits) is not used in your package, according to your test. So I modified the package.json file to exclude the useless dependency. Would you consider removing useless dependencies from your package, so that developers do not need to install them when they use your package?